### PR TITLE
Improve public room browser UI

### DIFF
--- a/packages/react-frontend/src/pages/Join/Join.jsx
+++ b/packages/react-frontend/src/pages/Join/Join.jsx
@@ -1,18 +1,31 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import "./join.css";
 import logoImage from "../../assets/logo.png";
 import OtherBackground from "../../../animationFiles/other-background.jsx";
 
-const songs = [
-  { id: 1, name: "Song Name", artist: "Artist Name", album: "Album Name" },
-  { id: 2, name: "Song Name", artist: "Artist Name", album: "Album Name" },
-  { id: 3, name: "Song Name", artist: "Artist Name", album: "Album Name" },
-  { id: 4, name: "Song Name", artist: "Artist Name", album: "Album Name" },
+const publicRooms = [
+  { id: 1, name: "Beach Mix", host: "Nick", listeners: 5, code: "BEACH1" },
+  { id: 2, name: "Study Beats", host: "Demo", listeners: 3, code: "STUDY2" },
+  { id: 3, name: "Party Queue", host: "Alex", listeners: 8, code: "PARTY3" },
+  { id: 4, name: "Road Trip", host: "Sam", listeners: 4, code: "ROAD04" },
 ];
 
 function Join() {
   const navigate = useNavigate();
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const filteredRooms = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+
+    if (!normalizedSearch) return publicRooms;
+
+    return publicRooms.filter((room) =>
+      [room.name, room.host, room.code].some((value) =>
+        value.toLowerCase().includes(normalizedSearch)
+      )
+    );
+  }, [searchTerm]);
 
   return (
     <div className="join-page">
@@ -31,24 +44,44 @@ function Join() {
 
         <section className="join-search-wrap">
           <div className="join-search-bar">
-            <input type="text" placeholder="Search for Room Name" />
+            <input
+              type="search"
+              placeholder="Search public rooms"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              aria-label="Search public rooms"
+            />
             <button aria-label="join by code" onClick={() => navigate("/home/code")} type="button">
-              =
+              #
             </button>
           </div>
         </section>
 
         <section className="join-list">
-          {songs.map((song) => (
-            <article className="join-song-row" key={song.id} onClick={() => navigate("/home/code")}>
-              <div className="join-album-cover">Album Cover</div>
-              <div className="join-song-meta">
-                <span>{song.name}</span>
-                <span>{song.artist}</span>
-                <span>{song.album}</span>
+          {filteredRooms.map((room) => (
+            <button
+              className="join-room-row"
+              key={room.id}
+              onClick={() => navigate("/home/code")}
+              type="button"
+            >
+              <div className="join-room-code">{room.code}</div>
+              <div className="join-room-meta">
+                <span>{room.name}</span>
+                <span>Hosted by {room.host}</span>
+                <span>{room.listeners} listeners</span>
               </div>
-            </article>
+            </button>
           ))}
+
+          {!filteredRooms.length && (
+            <div className="join-empty-state">
+              <p>No public rooms match that search.</p>
+              <button type="button" onClick={() => setSearchTerm("")}>
+                Clear search
+              </button>
+            </div>
+          )}
         </section>
       </div>
     </div>

--- a/packages/react-frontend/src/pages/Join/join.css
+++ b/packages/react-frontend/src/pages/Join/join.css
@@ -143,7 +143,7 @@
   gap: 24px;
 }
 
-.join-song-row {
+.join-room-row {
   min-height: 108px;
   display: grid;
   grid-template-columns: minmax(140px, 1fr) minmax(220px, 1.1fr) auto;
@@ -154,6 +154,7 @@
   overflow: hidden;
   cursor: pointer;
   border: 4px solid var(--bubble-highlight);
+  font: inherit;
   border-radius: 360px;
   background:
     linear-gradient(var(--bubble-highlight) 0 0) calc(100% - 76px) 14px / 44px 12px no-repeat,
@@ -184,23 +185,29 @@
   animation: joinBubbleRise 1.6s cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
-.join-song-row:nth-child(1) {
+.join-room-row:nth-child(1) {
   animation-delay: 0.1s;
 }
 
-.join-song-row:nth-child(2) {
+.join-room-row:nth-child(2) {
   animation-delay: 0.24s;
 }
 
-.join-song-row:nth-child(3) {
+.join-room-row:nth-child(3) {
   animation-delay: 0.38s;
 }
 
-.join-song-row:nth-child(4) {
+.join-room-row:nth-child(4) {
   animation-delay: 0.52s;
 }
 
-.join-album-cover {
+.join-room-row:focus-visible,
+.join-room-row:hover {
+  transform: translateY(-2px);
+  box-shadow: 6px 6px 0 rgba(0, 0, 0, 0.22);
+}
+
+.join-room-code {
   min-height: 76px;
   border-radius: 28px;
   background: rgba(255, 255, 255, 0.55);
@@ -211,9 +218,11 @@
   font-size: 22px;
   padding: 12px;
   text-align: center;
+  font-weight: 700;
+  letter-spacing: 0;
 }
 
-.join-song-meta {
+.join-room-meta {
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -221,7 +230,7 @@
   gap: 6px;
 }
 
-.join-song-meta span {
+.join-room-meta span {
   min-width: 220px;
   background: rgba(255, 255, 255, 0.6);
   border: 2px solid rgba(238, 251, 255, 0.9);
@@ -231,6 +240,36 @@
   font-size: 18px;
   line-height: 1.2;
   padding: 4px 14px;
+}
+
+.join-empty-state {
+  min-height: 150px;
+  display: grid;
+  place-items: center;
+  gap: 12px;
+  padding: 24px;
+  border: 4px solid var(--bubble-highlight);
+  border-radius: 44px;
+  background: rgba(159, 215, 228, 0.88);
+  color: var(--text-dark);
+  text-align: center;
+  box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.18);
+}
+
+.join-empty-state p {
+  margin: 0;
+  font-size: 20px;
+}
+
+.join-empty-state button {
+  min-height: 40px;
+  padding: 0 20px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(8, 48, 71, 0.86);
+  color: #ffffff;
+  font-size: 16px;
+  cursor: pointer;
 }
 
 .join-votes {
@@ -282,22 +321,22 @@
     gap: 10px;
   }
 
-  .join-song-row {
+  .join-room-row {
     height: auto;
     grid-template-columns: 1fr;
     border-radius: 44px;
     padding: 18px;
   }
 
-  .join-album-cover {
+  .join-room-code {
     min-height: 100px;
   }
 
-  .join-song-meta {
+  .join-room-meta {
     padding: 12px;
   }
 
-  .join-song-meta span {
+  .join-room-meta span {
     min-width: 0;
     width: 100%;
   }


### PR DESCRIPTION
Updated the Join page to make public room browsing clearer and easier to use.

Changes:
- Replaced generic song placeholder rows with public room cards
- Added room names, host names, listener counts, and room codes
- Added search filtering for public rooms
- Added an empty search state with a clear-search action
- Made room rows real buttons for better keyboard accessibility

Tested with npm run build.